### PR TITLE
Add `exports.types` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts"
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js"
+      "default": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Added the types file path to `exports.types` in package.json to prevent the following error: 
```
Could not find a declaration file for module '@mondaycom/apps-sdk'. '/Users/diprobhowmik/Documents/Development/monday-code-demo/next-js-typescript-test/node_modules/@mondaycom/apps-sdk/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/Users/diprobhowmik/Documents/Development/monday-code-demo/next-js-typescript-test/node_modules/@mondaycom/apps-sdk/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@mondaycom/apps-sdk' library may need to update its package.json or typings.
```

The reason behind this error is that node will ignore the `types` field if the package has an `exports` field. And since the `exports` didn't include an `exports.types`, node would not be able to find the relevant types .

Docs & stackoverflow here – 
https://stackoverflow.com/a/76212193 
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing