### PR TITLE
fix: refresh local db state before writes

### DIFF
--- a/lib/utils/local-db.ts
+++ b/lib/utils/local-db.ts
@@ -87,8 +87,14 @@ export class LocalDb implements ILocalStorageInstance {
     
     this.memoryData = {};
   }
+
+  private refreshMemoryData() {
+    const stringifiedDbData = readFileSync(this.dbFilePath, 'utf-8');
+    this.memoryData = isDefined(stringifiedDbData) ? JSON.parse(stringifiedDbData) : {};
+  }
   
   async set<T>(key: string, value: T) {
+    this.refreshMemoryData();
     this.memoryData[key] = value;
     
     writeFileSync(this.dbFilePath, JSON.stringify(this.memoryData));
@@ -96,6 +102,7 @@ export class LocalDb implements ILocalStorageInstance {
   }
   
   async delete(key: string) {
+    this.refreshMemoryData();
     delete this.memoryData[key];
     
     writeFileSync(this.dbFilePath, JSON.stringify(this.memoryData));

--- a/tests/utils/local-db.test.ts
+++ b/tests/utils/local-db.test.ts
@@ -154,6 +154,29 @@ describe('local-db', () => {
 
           expect(writeFileSync).toBeCalledWith(expect.any(String), MOCK_STORED_DATA);
         });
+
+        it('should keep values written by another local db instance', async () => {
+          let storedData = { [MOCK_KEY]: MOCK_VALUE };
+          (readFileSync as jest.Mock).mockImplementation(() => JSON.stringify(storedData));
+          (writeFileSync as jest.Mock).mockImplementation((_path, data: string) => {
+            storedData = JSON.parse(data) as typeof storedData;
+          });
+
+          const firstDbInstance = new localDb.LocalDb();
+          const secondDbInstance = new localDb.LocalDb();
+
+          await firstDbInstance.set('first', 'first-value');
+          await secondDbInstance.set('second', 'second-value');
+
+          expect(writeFileSync).toHaveBeenLastCalledWith(
+            expect.any(String),
+            JSON.stringify({
+              [MOCK_KEY]: MOCK_VALUE,
+              first: 'first-value',
+              second: 'second-value',
+            }),
+          );
+        });
       });
 
       describe('delete', () => {
@@ -161,6 +184,28 @@ describe('local-db', () => {
           await localDbInstance.delete(MOCK_KEY);
 
           expect(writeFileSync).toBeCalledWith(expect.any(String), MOCK_EMPTY_STORED_DATA);
+        });
+
+        it('should keep values written by another local db instance', async () => {
+          let storedData = { [MOCK_KEY]: MOCK_VALUE, first: 'first-value' };
+          (readFileSync as jest.Mock).mockImplementation(() => JSON.stringify(storedData));
+          (writeFileSync as jest.Mock).mockImplementation((_path, data: string) => {
+            storedData = JSON.parse(data) as typeof storedData;
+          });
+
+          const firstDbInstance = new localDb.LocalDb();
+          const secondDbInstance = new localDb.LocalDb();
+
+          await firstDbInstance.set('second', 'second-value');
+          await secondDbInstance.delete(MOCK_KEY);
+
+          expect(writeFileSync).toHaveBeenLastCalledWith(
+            expect.any(String),
+            JSON.stringify({
+              first: 'first-value',
+              second: 'second-value',
+            }),
+          );
         });
 
         it('should not fail for multiple deletions of the same key', async () => {


### PR DESCRIPTION
## Summary

- refresh `LocalDb` from disk immediately before `set` and `delete`
- add regression coverage for two `LocalDb` instances writing/deleting against the same backing file

This addresses #71. Previously, a `LocalDb` instance could keep a stale in-memory snapshot from construction time and then overwrite keys written by another instance when it later saved its own snapshot.

## Verification

- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn test tests/utils/local-db.test.ts --runInBand`
- `npx prettier --check lib/utils/local-db.ts tests/utils/local-db.test.ts`
- `npx eslint lib/utils/local-db.ts tests/utils/local-db.test.ts --ext .ts --config .eslintrc.json`
- `yarn build:esm`
- `yarn build:cjs`
- `git diff --check`

Notes: ESLint reports the existing `no-explicit-any` warnings in `lib/utils/local-db.ts`; there are no lint errors from this change. `git diff --check` only reported local CRLF warnings on Windows.

This was implemented with Codex assistance, with the final diff manually reviewed and kept focused.
